### PR TITLE
OutOfMemoryException when sending big files

### DIFF
--- a/grails-app/controllers/org/grails/plugins/fileserver/FileController.groovy
+++ b/grails-app/controllers/org/grails/plugins/fileserver/FileController.groovy
@@ -13,7 +13,12 @@ class FileController {
 
         if (file) {
             log.debug("$root/$path, sending file: $file.absolutePath")
-            response.outputStream << file.bytes
+            // inspired by answer of tim_yates of http://stackoverflow.com/a/15379941/1323837
+            // using this implementation, which does not load the file into memory
+            // important for big files and/or servers with very limited memory
+            file.withInputStream {
+                response.outputStream << it
+            }
         } else {
             log.debug("$root/$path, file not found - dir: $basePath, file: $path")
             response.status = 404


### PR DESCRIPTION
Inspired by [tim_yates' answer](http://stackoverflow.com/a/15379941/1323837) on stackoverflow.com, I suggest to change the implementation of sending the bytes from the server to the client.
Trying to send big files (exceeding the heap) throws an OutOfMemoryException, since the Java heap memory is insufficient. 

Once this issue is fixed, please provide the updated plugin in the Grails plugin repository.

Thanks a lot!
Cheers
